### PR TITLE
Added bottom padding if the window is maximized

### DIFF
--- a/assets/components/modalconsole/css/mgr/modalconsole.css
+++ b/assets/components/modalconsole/css/mgr/modalconsole.css
@@ -12,6 +12,9 @@
 #modalconsole-window.visible {
 	top: 55px !important;
 }
+#modalconsole-window.x-window-maximized {
+	padding-bottom: 55px !important;
+}
 #modalconsole-window .x-window-body {
 	padding: 0;
 	overflow: hidden;


### PR DESCRIPTION
If the window is maximized, then the buttons go off the screen.
Padding fixes that.

Before:
![mc_1](https://user-images.githubusercontent.com/12523676/92097649-02493c80-ede1-11ea-8d0b-a66740d0216e.gif)

After:
![mc_2](https://user-images.githubusercontent.com/12523676/92097652-02e1d300-ede1-11ea-87ae-896dd3101171.png)