### PR TITLE
Added console position setting

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -3,31 +3,36 @@
 $settings = array();
 
 $tmp = array(
+	'cssUrl' => array(
+		'xtype' => 'textfield',
+		'value' => '{assets_url}components/modalconsole/css/mgr/modalconsole.css',
+		'area' => 'modalconsole_main',
+	),
+	'enable' => array(
+		'xtype' => 'combo-boolean',
+		'value' => true,
+		'area' => 'modalconsole_main',
+	),
+	'files_path' => array(
+		'xtype' => 'textfield',
+		'value' => '{core_path}components/modalconsole/files/',
+		'area' => 'modalconsole_main',
+	),
 	'history_limit' => array(
 		'xtype' => 'numberfield',
 		'value' => 20,
 		'area' => 'modalconsole_main',
 	),
-    'cssUrl' => array(
-		'xtype' => 'textfield',
-		'value' => '{assets_url}components/modalconsole/css/mgr/modalconsole.css',
-		'area' => 'modalconsole_main',
-	),
-    'jsUrl' => array(
+	'jsUrl' => array(
 		'xtype' => 'textfield',
 		'value' => '{assets_url}components/modalconsole/js/mgr/modalconsole.js',
 		'area' => 'modalconsole_main',
 	),
-    'enable' => array(
-        'xtype' => 'combo-boolean',
-        'value' => true,
-        'area' => 'modalconsole_main',
-    ),
-    'files_path' => array(
-        'xtype' => 'textfield',
-        'value' => '{core_path}components/modalconsole/files/',
-        'area' => 'modalconsole_main',
-    ),
+	'position' => array(
+		'xtype' => 'textfield',
+		'value' => 'right',
+		'area' => 'modalconsole_main',
+	),
 );
 
 foreach ($tmp as $k => $v) {

--- a/assets/components/modalconsole/css/mgr/modalconsole.css
+++ b/assets/components/modalconsole/css/mgr/modalconsole.css
@@ -1,6 +1,4 @@
 #modalconsole-window {
-	left: auto !important;
-	right: 0 !important;
 	-webkit-transition: top 0.7s ease-out 0s;
 	-moz-transition: top 0.7s ease-out 0s;
 	-o-transition: top 0.7s ease-out 0s;
@@ -8,6 +6,14 @@
 	opacity: 0.5;
 	position: absolute;
 	z-index: 18 !important;
+}
+#modalconsole-window.left {
+	left: 0 !important;
+	right: auto !important;
+}
+#modalconsole-window.right {
+	right: 0 !important;
+	left: auto !important;
 }
 #modalconsole-window.visible {
 	top: 55px !important;

--- a/assets/components/modalconsole/js/mgr/modalconsole.js
+++ b/assets/components/modalconsole/js/mgr/modalconsole.js
@@ -48,6 +48,7 @@ let modalConsoleWindow = function (config) {
 		renderTo: 'modx-container',
 		title: _('modalconsole'),
 		id: 'modalconsole-window',
+		cls: (MODx.config.modalconsole_position ? Ext.util.Format.htmlEncode(MODx.config.modalconsole_position) : 'right'),
 		width: 950,
 		minHeight: 200,
 		minWidth: 300,

--- a/core/components/modalconsole/lexicon/en/setting.inc.php
+++ b/core/components/modalconsole/lexicon/en/setting.inc.php
@@ -2,13 +2,15 @@
 
 $_lang['area_modalconsole_main'] = 'Main';
 
-$_lang['setting_modalconsole_history_limit'] = 'History limit';
-$_lang['setting_modalconsole_history_limit_desc'] = 'Number of requests to save it the history. 0 - to disable saving the request history.';
 $_lang['setting_modalconsole_cssUrl'] = 'Css file';
 $_lang['setting_modalconsole_cssUrl_desc'] = 'Enter css file URL or leave the field empty to prevent his loading.';
-$_lang['setting_modalconsole_jsUrl'] = 'Javascript file';
-$_lang['setting_modalconsole_jsUrl_desc'] = 'Enter javascript file URL or leave the field empty to prevent his loading.';
 $_lang['setting_modalconsole_enable'] = 'Enable the console';
-$_lang['setting_modalconsole_enable_desc'] = 'Enable the console.';
+$_lang['setting_modalconsole_enable_desc'] = 'Enable/disable the console.';
 $_lang['setting_modalconsole_files_path'] = 'Path to save files';
 $_lang['setting_modalconsole_files_path_desc'] = 'Path to save files.';
+$_lang['setting_modalconsole_history_limit'] = 'History limit';
+$_lang['setting_modalconsole_history_limit_desc'] = 'Number of requests to save it the history. 0 - to disable saving the request history.';
+$_lang['setting_modalconsole_jsUrl'] = 'Javascript file';
+$_lang['setting_modalconsole_jsUrl_desc'] = 'Enter javascript file URL or leave the field empty to prevent his loading.';
+$_lang['setting_modalconsole_position'] = 'Console position';
+$_lang['setting_modalconsole_position_desc'] = 'The position of the console relative to the screen. Available: left - console is always on the left, right - always on the right (used by default), auto - console drag is available.';

--- a/core/components/modalconsole/lexicon/ru/setting.inc.php
+++ b/core/components/modalconsole/lexicon/ru/setting.inc.php
@@ -2,13 +2,15 @@
 
 $_lang['area_modalconsole_main'] = 'Основные';
 
-$_lang['setting_modalconsole_history_limit'] = 'Количество запросов';
-$_lang['setting_modalconsole_history_limit_desc'] = 'Укажите, какое количество запросов будет хранится в кэше. 0 - отключает сохранение истории.';
 $_lang['setting_modalconsole_cssUrl'] = 'Файл стилей консоли';
 $_lang['setting_modalconsole_cssUrl_desc'] = 'Укажите файл стилей или оставьте поле пустым, чтобы отключить его загрузку.';
-$_lang['setting_modalconsole_jsUrl'] = 'Файл скриптов консоли';
-$_lang['setting_modalconsole_jsUrl_desc'] = 'Укажите файл со скриптами или оставьте поле пустым, чтобы отключить его загрузку.';
 $_lang['setting_modalconsole_enable'] = 'Включить консоль';
-$_lang['setting_modalconsole_enable_desc'] = 'Включить консоль.';
+$_lang['setting_modalconsole_enable_desc'] = 'Включить/выключить консоль.';
 $_lang['setting_modalconsole_files_path'] = 'Путь к файлам';
 $_lang['setting_modalconsole_files_path_desc'] = 'Путь к сохранённым файлам.';
+$_lang['setting_modalconsole_history_limit'] = 'Количество запросов';
+$_lang['setting_modalconsole_history_limit_desc'] = 'Укажите, какое количество запросов будет хранится в кэше. 0 - отключает сохранение истории.';
+$_lang['setting_modalconsole_jsUrl'] = 'Файл скриптов консоли';
+$_lang['setting_modalconsole_jsUrl_desc'] = 'Укажите файл со скриптами или оставьте поле пустым, чтобы отключить его загрузку.';
+$_lang['setting_modalconsole_position'] = 'Положение консоли';
+$_lang['setting_modalconsole_position_desc'] = 'Положение консоли относительно экрана. Доступно: left - консоль всегда слева, right - всегда справа (используется по умолчанию), auto - доступно перетаскивание консоли.';


### PR DESCRIPTION
Added a setting for the position of the console, you can set it to the left, right or auto.

![console_pos](https://user-images.githubusercontent.com/12523676/93205088-e722e900-f75f-11ea-8478-1304981245bb.gif)

Also, lexicons and settings are arranged alphabetically.